### PR TITLE
Fix capitalization of GitHub on "Everything You Need" page

### DIFF
--- a/everything-you-need.html
+++ b/everything-you-need.html
@@ -20,7 +20,7 @@
         <img src="images/everything.png" alt="So many possibilities">
       </figure>
 
-      <p>Ruby on Rails is not a minimalist framework, it's a metropolis. One filled with all the major institutions needed to run a large, sprawling application like Basecamp or Github or Shopify.</p>
+      <p>Ruby on Rails is not a minimalist framework, it's a metropolis. One filled with all the major institutions needed to run a large, sprawling application like Basecamp or GitHub or Shopify.</p>
 
       <p>This means there's a lot to learn! But it also means you can learn it piece by piece. You do not need to be an expert in all facets of Ruby on Rails to get started on creating a great application.</p>
 


### PR DESCRIPTION
This updates the capitalization of "Github" to be "GitHub" since that is how it is spelt on the homepage of the Rails site and on GitHub.