### PR TITLE
Replaced markdown _ with <em> tags

### DIFF
--- a/doctrine.html
+++ b/doctrine.html
@@ -120,7 +120,7 @@
 
       <p>How do you know what to order in a restaurant when you don’t know what’s good? Well, if you let the chef choose, you can probably assume a good meal, even before you know what “good” is. That is omakase. A way to eat well that requires you neither be an expert in the cuisine or blessed with blind luck at picking in the dark.
 
-      <p>For programming, the benefits of this practice, letting others assemble your stack, is similar to those we derive from Convention over Configuration, but at a higher level. Where CoC is occupied with how we best use of individual frameworks, omakase is concerned with _which_ frameworks, and how they fit together.
+      <p>For programming, the benefits of this practice, letting others assemble your stack, is similar to those we derive from Convention over Configuration, but at a higher level. Where CoC is occupied with how we best use of individual frameworks, omakase is concerned with <em>which</em> frameworks, and how they fit together.
 
       <p>This is at odds with the revered programming tradition of presenting available tools as individual choices, and to bestow the individual programmer privilege (and burden!) of deciding. 
 


### PR DESCRIPTION
Was reading the document and noticed this.