### PR TITLE
Reduce font size on mobile displays

### DIFF
--- a/style.css
+++ b/style.css
@@ -168,6 +168,9 @@ RESPONSIVE CSS
 
 /* iPhone */
 @media only screen and (max-device-width: 480px) {
+  body {
+    font-size: 18px;
+  }
   .container { width: auto; margin: 0; }
   .mobile-center { text-align: center; }
   section { width: auto; }

--- a/style.css
+++ b/style.css
@@ -169,7 +169,7 @@ RESPONSIVE CSS
 /* iPhone */
 @media only screen and (max-device-width: 480px) {
   body {
-    font-size: 18px;
+    font-size: 1.2rem;
   }
   .container { width: auto; margin: 0; }
   .mobile-center { text-align: center; }


### PR DESCRIPTION
The font-size on mobile displays means that only a small amount of text appears on the page, requiring a lot of scrolling to read it. I propose that the font-size is reduced to 18px, which changes it from this:

![img_0021](https://cloud.githubusercontent.com/assets/2687/12437131/61cc332e-bf6f-11e5-8739-5a939d698321.PNG)

To the (still quite readable) this:

![img_0022](https://cloud.githubusercontent.com/assets/2687/12437150/704a746a-bf6f-11e5-8447-a0b04fc9a2b8.PNG)

