### PR TITLE
fix a small typo

### DIFF
--- a/doctrine.html
+++ b/doctrine.html
@@ -103,7 +103,7 @@
 
       <p>Part of the Rails’ mission is to swing its machete at the thick, and ever growing, jungle of recurring decisions that face developers creating information systems for the web. There are thousands of such decisions that just need to be made once, and if someone else can do it for you, all the better.</p>
 
-      <p>Not only does the transfer of configuration to convention free us from deliberation, it also provides a lush field to grow deeper abstractions. If we can depend on a Person class mapping to people table, we can use that same inflection to map a association declared as has_many :people to look for a Person class. The power of good conventions is that they pay dividends across a wide spectrum of use.</p>
+      <p>Not only does the transfer of configuration to convention free us from deliberation, it also provides a lush field to grow deeper abstractions. If we can depend on a Person class mapping to people table, we can use that same inflection to map an association declared as has_many :people to look for a Person class. The power of good conventions is that they pay dividends across a wide spectrum of use.</p>
 
       <p>But beyond the productivity gains for experts, conventions also lower the barriers of entry for beginners. There are so many conventions in Rails that a beginner doesn’t even need to know about, but can just benefit from in ignorance. It’s possible to create great applications without knowing why everything is the way it is.</p>
 


### PR DESCRIPTION
"a association" to "an association"