### PR TITLE
Redirects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'github-pages'
+gem 'jekyll-redirect-from'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,7 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
+  jekyll-redirect-from
 
 BUNDLED WITH
    1.11.2

--- a/_config.yml
+++ b/_config.yml
@@ -2,3 +2,6 @@ exclude:
   - Gemfile
   - Gemfile.lock
   - CNAME
+
+gems:
+  - jekyll-redirect-from

--- a/community.html
+++ b/community.html
@@ -15,11 +15,11 @@ permalink: /community/
 
       <p>You can meet the community online on the <a href="https://groups.google.com/forum/#!forum/rubyonrails-talk">Ruby on Rails: Talk mailing list</a>, <a href="http://stackoverflow.com/questions/tagged/ruby-on-rails">the Ruby on Rails StackOverflow Q&A tag</a>, or the #rubyonrails IRC channel on irc.freenode.net. We also do a yearly <a href="http://railsconf.com">RailsConf</a> conference for people to meet in real life.</p>
 
-      <h2>The core team</h2>
+      <h2 id="core">The core team</h2>
 
       <p>The direction of the framework is being stewarded by the Rails core team. This group of long-term contributors manage releases, evaluate pull-requests, handle conduct complaints, and does a lot of the groundwork on major new features.</p>
 
-      <div class="rails-core" id="core">
+      <div class="rails-core">
         <div class="person">
           <a href="https://twitter.com/dhh" target="_blank">
             <figure class="contributor david">

--- a/core.html
+++ b/core.html
@@ -1,0 +1,6 @@
+---
+title: Core Team
+permalink: /core/
+redirect_to:
+  - /community/#core
+---


### PR DESCRIPTION
This adds the [jekyll-redirect-from](https://github.com/jekyll/jekyll-redirect-from) gem to the project and fixes issue #7 by adding an initial redirect from `/core/` to `/community/#core`.

@matthewd would you mind take a look at this? A demo is set up at [http://jyunderwood.github.io/core/]() to verify functionality. 