### PR TITLE
Clarify contribution language

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@ layout: default
 
       <p><strong>You’ve probably already used many of the applications that were built with Ruby on Rails:</strong> <a href="https://basecamp.com">Basecamp</a>, <a href="https://github.com">GitHub</a>, <a href="https://shopify.com">Shopify</a>, <a href="https://airbnb.com">Airbnb</a>, <a href="https://twitch.tv">Twitch</a>, <a href="https://soundcloud.com">SoundCloud</a>, <a href="https://hulu.com">Hulu</a>, <a href="https://zendesk.com">Zendesk</a>, <a href="https://square.com">Square</a>, <a href="https://highrisehq.com">Highrise</a>. Those are just some of the big names, but there are literally hundreds of thousands of applications built with the framework since its release in 2004.</p>
 
-      <p><strong>Ruby on Rails is open source software</strong>, so not only is it free to use, you can also help make it better. <a href="http://contributors.rubyonrails.org">More than 4,200 people</a> already have their code in Rails. It’s easier than you think to become one of them.</p>
+      <p><strong>Ruby on Rails is open source software</strong>, so not only is it free to use, you can also help make it better. <a href="http://contributors.rubyonrails.org">More than 4,200 people</a> already have contributed code to Rails. It’s easier than you think to become one of them.</p>
 
       <p><strong>Optimizing for programmer happiness with Convention over Configuration</strong> is how we roll. Ruby on Rails has been popularizing both concepts along with a variety of other controversial points since the beginning. To learn more about why Rails is so different from many other web-application frameworks and paradigms, examine <a href="doctrine">The Rails Doctrine</a>.</p>
     </section>


### PR DESCRIPTION
This is a trivial change, but figured I'd PR it regardless:

"4,200 people already have their code in Rails" could be interpreted as those people having written _apps_ in Rails. This commit changes the language to be more clear that those 4,200 people have contributed code to Rails itself.