### PR TITLE
Fix little typo on Ruby Hero Awards

### DIFF
--- a/community.html
+++ b/community.html
@@ -195,7 +195,7 @@
 
       <h2>All other contributors</h2>
 
-      <p>On top of these formal teams, there are thousands of other code contributors. We've tracked everyone's work on the <a href="http://contributors.rubyonrails.org">Rails Contributors site</a>. Beyond code contributors, the community also recognizes people who contribute in all sorts of other ways, including documentation, evangelism, organizing, and more. We share recognition of some of those with Ruby as part of the <a href="http://rubyheroes.com">Ruby Heroes Awards</a>.</p>
+      <p>On top of these formal teams, there are thousands of other code contributors. We've tracked everyone's work on the <a href="http://contributors.rubyonrails.org">Rails Contributors site</a>. Beyond code contributors, the community also recognizes people who contribute in all sorts of other ways, including documentation, evangelism, organizing, and more. We share recognition of some of those with Ruby as part of the <a href="http://rubyheroes.com">Ruby Hero Awards</a>.</p>
 
       <p class="back">
         <a href="index.html">&larr; Back to homepage</a>


### PR DESCRIPTION
No biggie :-)

I'm getting the [new site](https://rubyheroes-production-pr-2.herokuapp.com/) ready and I appreciate the link by the way.