### PR TITLE
Update maintenance policy to include Rails 5.

### DIFF
--- a/maintenance.html
+++ b/maintenance.html
@@ -31,7 +31,7 @@ permalink: /maintenance/
 
       <p>In special situations, where someone from the Rails core team agrees to support more series, they are included in the list of supported series.</p>
 
-      <p>Currently included series: 4.2.Z, 4.1.Z.</p>
+      <p>Currently included series: 5.0.Z.</p>
 
       <h2>Security issues</h2>
       <p>See the <a href="/security/">security policy</a> for more details.</p>

--- a/security.html
+++ b/security.html
@@ -15,9 +15,7 @@ permalink: /security/
 
       <h2>Supported versions</h2>
 
-      <p>For major security issues, the current release series, the next most recent one, and the last additional major series will receive patches and new versions. This is currently 4.2.x, 4.1.x, 3.2.x.</p>
-
-      <p>For minor security issues, the current release series and the next most recent one will receive patches and new versions. This is currently 4.2.x and 4.1.x.</p>
+      <p>For major and minor security issues, the current release series and the next most recent one will receive patches and new versions. This is currently 5.0.x, 4.2.x.</p>
 
       <p>When a release series is no longer supported, it’s your own responsibility to deal with bugs and security issues. We may provide backports of the fixes and publish them to git, however there will be no new versions released. If you are not comfortable maintaining your own versions, you should upgrade to a supported version.</p>
 


### PR DESCRIPTION
Copy over the new maintenance policy from the release post:
http://weblog.rubyonrails.org/2016/6/30/Rails-5-0-final/

Summed up:

* Only 5.0.x gets bug fixes.
* Only 5.0.x and 4.2.x gets security fixes.

cc @rafaelfranca 