### PR TITLE
Tweak link styles and button

### DIFF
--- a/style.css
+++ b/style.css
@@ -17,6 +17,7 @@ small { font-size: 1rem; }
 img { border: 0; }
 
 a { color: #cc0000; text-decoration: none; }
+a:hover { padding-bottom: 2px; border-bottom: 2px solid #cc0000; }
 
 h1 {
   font-weight: normal;
@@ -54,8 +55,8 @@ NAV
 .nav ul { margin: 0; padding: 0; }
 .nav ul li { display: inline; list-style-type: none; margin-left: 20px; }
 .nav ul li.first { margin-left: 5px; }
-.nav ul li a { font-weight: bold; border-bottom: 2px solid #ff9999; }
-.nav ul li a:hover { color: #000; border-bottom: 2px solid #cc0000; }
+.nav ul li a { padding-bottom: 1px; font-weight: bold; border-bottom: 2px solid #cc0000; }
+.nav ul li a:hover { color: #000; border-bottom: 2px solid #000; }
 
 .back { margin: 4rem 0; text-align: center; font-size: 1rem; }
 
@@ -89,6 +90,10 @@ figure.left { float:left; margin-left: -5rem; }
   background-color: #cc0000;
   padding: 1.3rem 2rem;
   border-radius: 20px;
+}
+
+.version a:hover {
+  opacity: 0.8;
 }
 
 .video-container {


### PR DESCRIPTION
Consistent color on nav links
Add border bottom to hyperlinks (hover)
Add hover effect to red button

@fxn Hi Xavier! Here are the first couple of changes I suggested in the email. See changes live at https://vis-kid.github.io/homepage/. Happy to continue in this direction if you are happy with the results. 😃 

Nav link colors:
Before: Three colors

<img width="859" alt="screen shot 2016-08-20 at 1 56 36 am" src="https://cloud.githubusercontent.com/assets/1353214/17827667/387a4560-6681-11e6-866e-0479b9ee6754.png">

After: Two colors

<img width="889" alt="screen shot 2016-08-16 at 2 55 00 pm" src="https://cloud.githubusercontent.com/assets/1353214/17827677/55754dfe-6681-11e6-93e4-98f59ccc78b5.png">

Links with border-bottom on hover:

<img width="469" alt="screen shot 2016-08-16 at 2 55 16 pm" src="https://cloud.githubusercontent.com/assets/1353214/17827727/31adfc94-6682-11e6-89fd-84d3f7418836.png">

Button with hover:

<img width="640" alt="screen shot 2016-08-20 at 1 59 26 am" src="https://cloud.githubusercontent.com/assets/1353214/17827700/9c20dbc4-6681-11e6-9e97-f377fd1cc613.png">

Button without hover:

<img width="645" alt="screen shot 2016-08-20 at 1 58 58 am" src="https://cloud.githubusercontent.com/assets/1353214/17827703/a5e4ea74-6681-11e6-88f7-8febbd247515.png">




