### PR TITLE
Add baseurl for assets

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,3 +5,5 @@ exclude:
 
 gems:
   - jekyll-redirect-from
+
+baseurl: /homepage

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,7 +4,7 @@
     <title>Ruby on Rails{% if page.title %}: {{ page.title }}{% endif %}</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width">
-    <link rel="stylesheet" href="/style.css" type="text/css" media="screen" charset="utf-8">
+    <link rel="stylesheet" href="{{ site.baseurl }}/style.css" type="text/css" media="screen" charset="utf-8">
   </head>
 
   <body>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,7 +3,7 @@ layout: default
 ---
 <div class="logo">
   <a href="/">
-    <img src="/images/rails-logo.svg" width="130" height="46" alt="Ruby on Rails">
+    <img src="{{ site.baseurl }}/images/rails-logo.svg" width="130" height="46" alt="Ruby on Rails">
   </a>
 </div>
 

--- a/community.html
+++ b/community.html
@@ -8,7 +8,7 @@ permalink: /community/
       <h1>Rails is made of people</h1>
 
       <figure class="right">
-        <img src="/images/community.png" alt="Community">
+      <img src="{{ site.baseurl }}/images/community.png" alt="Community">
       </figure>
 
       <p>Ruby on Rails is for everyone who wants to build web applications, whether they're 30-year veterans or only just started to learn yesterday. All are welcome!</p>

--- a/conduct.html
+++ b/conduct.html
@@ -8,7 +8,7 @@ permalink: /conduct/
       <h1>Code of Conduct</h1>
 
       <figure class="right">
-        <img src="/images/conduct.png" alt="Code of Conduct">
+      <img src="{{ site.baseurl }}/images/conduct.png" alt="Code of Conduct">
       </figure>
 
       <p>

--- a/doctrine.html
+++ b/doctrine.html
@@ -10,7 +10,7 @@ permalink: /doctrine/
 
 
       <figure class="right">
-        <img src="/images/doctrine.png" alt="The Rails Doctrine">
+      <img src="{{ site.baseurl }}/images/doctrine.png" alt="The Rails Doctrine">
       </figure>
 
       <p>Ruby on Rails’ phenomenal rise to prominence owed much of its lift-off to novel technology and timing. But technological advantages erode over time, and good timing doesn’t sustain movements alone over the long term. So a broader explanation of how Rails has continued to not only stay relevant but to grow its impact and community is needed. I propose that the enduring enabler has been and remains its controversial doctrine.</p>

--- a/everything-you-need.html
+++ b/everything-you-need.html
@@ -8,7 +8,7 @@ permalink: /everything-you-need/
       <h1>Rails has everything you need</h1>
 
       <figure class="right">
-        <img src="/images/everything.png" alt="So many possibilities">
+      <img src="{{ site.baseurl }}/images/everything.png" alt="So many possibilities">
       </figure>
 
       <p>Ruby on Rails is not a minimalist framework, it's a metropolis. One filled with all the major institutions needed to run a large, sprawling application like Basecamp or GitHub or Shopify.</p>
@@ -18,7 +18,7 @@ permalink: /everything-you-need/
       <p>The spine of a Rails application is the Model-View-Controller pattern that organizes programming logic into three major layers. The model is where your so-called business logic lives. This is where you calculate whether the next invoice is due or how many todos are left to be completed on a project. The controller is what accepts clicks and taps from the user, routes the commands to the model, and then renders HTML or JSON templates as the view.</p>
 
       <figure class="left">
-        <img src="/images/action-pack.png" alt="Action Pack">
+      <img src="{{ site.baseurl }}/images/action-pack.png" alt="Action Pack">
       </figure>
 
       <p>In Rails, the model is chiefly handled by Active Record (with some backup from Active Model). That's the framework for talking to the database. The controller is handled by Action Controller and the view by Action View, together presented as Action Pack.</p>

--- a/index.html
+++ b/index.html
@@ -14,13 +14,13 @@ layout: default
 
     <section>
       <p class="mobile-center">
-        <img src="/images/rails-logo.svg" width="220" height="78" alt="Ruby on Rails">
+      <img src="{{ site.baseurl }}/images/rails-logo.svg" width="220" height="78" alt="Ruby on Rails">
       </p>
     </section>
 
     <section>
       <figure class="right">
-        <img src="/images/imagine.png" alt="So many possibilities.">
+      <img src="{{ site.baseurl }}/images/imagine.png" alt="So many possibilities.">
       </figure>
 
       <h1>Imagine what you could build if you learned Ruby on Rails&#8230;</h1>
@@ -38,7 +38,7 @@ layout: default
 
     <section class="interior">
       <figure class="left">
-        <img src="/images/rubyrails.png" alt="Rails does it all.">
+      <img src="{{ site.baseurl }}/images/rubyrails.png" alt="Rails does it all.">
       </figure>
 
       <p><strong>You’ve probably already used many of the applications that were built with Ruby on Rails:</strong> <a href="https://basecamp.com">Basecamp</a>, <a href="https://github.com">GitHub</a>, <a href="https://shopify.com">Shopify</a>, <a href="https://airbnb.com">Airbnb</a>, <a href="https://twitch.tv">Twitch</a>, <a href="https://soundcloud.com">SoundCloud</a>, <a href="https://hulu.com">Hulu</a>, <a href="https://zendesk.com">Zendesk</a>, <a href="https://square.com">Square</a>, <a href="https://highrisehq.com">Highrise</a>. Those are just some of the big names, but there are literally hundreds of thousands of applications built with the framework since its release in 2004.</p>
@@ -50,7 +50,7 @@ layout: default
 
     <section class="more">
       <figure>
-        <img src="/images/more.png" alt="More resources">
+      <img src="{{ site.baseurl }}/images/more.png" alt="More resources">
       </figure>
 
       <p>Keep up to date with <a href="https://twitter.com/rails">Rails on Twitter</a> and <a href="https://rails-weekly.ongoodbits.com">This Week in Rails</a></p>

--- a/maintenance.html
+++ b/maintenance.html
@@ -8,7 +8,7 @@ permalink: /maintenance/
       <h1>Maintenance policy</h1>
 
       <figure class="right">
-        <img src="/images/maintenance.png" alt="Maintenance">
+      <img src="{{ site.baseurl }}/images/maintenance.png" alt="Maintenance">
       </figure>
 
       <p>

--- a/security.html
+++ b/security.html
@@ -8,7 +8,7 @@ permalink: /security/
       <h1>Security policy</h1>
 
       <figure class="right">
-        <img src="/images/security.png" alt="Security.">
+      <img src="{{ site.baseurl }}/images/security.png" alt="Security.">
       </figure>
 
       <p>Ruby on Rails takes web security very seriously. This means including features to protect application makers from common issues like CRSF, Script Injection, SQL Injection, and the like. But it also means a clear policy on how to report vulnerabilities and receive updates when patches to those are released.</p>


### PR DESCRIPTION
Assets now stay intact on deployed gh-pages branch from fork
Add `baseurl: /homepage` to config file (user/org.github.io/homepage)
Add baseurl to style asset link in head tag
Add baseurl to image asset paths