### PR TITLE
Tweak navbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,20 +3,15 @@ layout: default
 ---
 
     <div class="nav">
+      <a id="nav-logo" href="http://rubyonrails.org/"><img src="/images/rails-logo.svg" alt="Ruby on Rails"></a>
       <ul>
         <li class="first"><a href="http://weblog.rubyonrails.org/">Blog</a></li>
         <li><a href="http://guides.rubyonrails.org/">Guides</a></li>
         <li><a href="http://api.rubyonrails.org/">API</a></li>
-        <li><a href="http://stackoverflow.com/questions/tagged/ruby-on-rails">Ask for help</a></li>
-        <li><a href="https://github.com/rails/rails">Contribute on GitHub</a></li>
+        <li><a href="http://stackoverflow.com/questions/tagged/ruby-on-rails">Help</a></li>
+        <li><a href="https://github.com/rails/rails">Contribute</a></li>
       </ul>
     </div>
-
-    <section>
-      <p class="mobile-center">
-        <img src="/images/rails-logo.svg" width="220" height="78" alt="Ruby on Rails">
-      </p>
-    </section>
 
     <section>
       <figure class="right">

--- a/style.css
+++ b/style.css
@@ -49,11 +49,12 @@ h2 {
 NAV
 --------------------------------------------------*/
 
-.logo { text-align: center; margin: 1rem 0; }
-.logo a { border: 0; }
+#nav-logo img { width: 130px; margin-top: 60px; }
+#nav-logo:hover { opacity: 0.7; }
 
-.nav { margin-top: 30px; width: 500px; float: right; font-size: 14px; }
-.nav ul { margin: 0; padding: 0; }
+.nav { margin-left: 130px; }
+.nav { font-size: 15px; }
+.nav ul { margin: 0; padding: 0; float: right; margin-top: 80px; }
 .nav ul li { display: inline; list-style-type: none; margin-left: 20px; }
 .nav ul li.first { margin-left: 5px; }
 .nav ul li a { padding-bottom: 1px; font-weight: bold; border-bottom: 2px solid #cc0000; }


### PR DESCRIPTION
Adjust navbar to blog navbar
Avoid navbar breaking into new line
Tighten link strings to save space
Add hover to logo
Reduce logo size
Remove obsolete styles

Preview changes [here](https://vis-kid.github.io/homepage/): 

# Blog navbar:
<img width="787" alt="screen shot 2016-08-29 at 6 33 39 pm" src="https://cloud.githubusercontent.com/assets/1353214/18061476/214069c0-6e23-11e6-8904-d19a1da61562.png">

# rubyonrails.org navbar:
<img width="902" alt="screen shot 2016-08-29 at 6 32 39 pm" src="https://cloud.githubusercontent.com/assets/1353214/18061501/39b7bf44-6e23-11e6-857d-2e2e4aa4eae1.png">

# Long link strings
<img width="608" alt="screen shot 2016-08-29 at 7 04 48 pm" src="https://cloud.githubusercontent.com/assets/1353214/18061515/4c4d90a2-6e23-11e6-8b9b-3a456bf2f14b.png">

# Tightened link strings:
<img width="443" alt="screen shot 2016-08-29 at 7 05 44 pm" src="https://cloud.githubusercontent.com/assets/1353214/18061558/74ff66c4-6e23-11e6-92bb-85d3abbaad3e.png">

# Logo with hover:
<img width="190" alt="screen shot 2016-08-29 at 6 33 10 pm" src="https://cloud.githubusercontent.com/assets/1353214/18061567/7c520cd8-6e23-11e6-9a98-25d5f364d08e.png">

# Logo without hover:
<img width="173" alt="screen shot 2016-08-29 at 6 33 19 pm" src="https://cloud.githubusercontent.com/assets/1353214/18061572/844863f6-6e23-11e6-8b2b-41affb376fd3.png">

# Logo size before
<img width="883" alt="screen shot 2016-08-29 at 6 32 53 pm" src="https://cloud.githubusercontent.com/assets/1353214/18061595/94d3e1be-6e23-11e6-9f74-9584f8d6b280.png">

# Logo size after
<img width="902" alt="screen shot 2016-08-29 at 6 32 39 pm" src="https://cloud.githubusercontent.com/assets/1353214/18061618/a92ff648-6e23-11e6-894d-3eebc8307dd7.png">