### PR TITLE
Fix CSRF typo on the security page

### DIFF
--- a/security.html
+++ b/security.html
@@ -11,7 +11,7 @@ permalink: /security/
         <img src="/images/security.png" alt="Security.">
       </figure>
 
-      <p>Ruby on Rails takes web security very seriously. This means including features to protect application makers from common issues like CRSF, Script Injection, SQL Injection, and the like. But it also means a clear policy on how to report vulnerabilities and receive updates when patches to those are released.</p>
+      <p>Ruby on Rails takes web security very seriously. This means including features to protect application makers from common issues like CSRF, Script Injection, SQL Injection, and the like. But it also means a clear policy on how to report vulnerabilities and receive updates when patches to those are released.</p>
 
       <h2>Supported versions</h2>
 


### PR DESCRIPTION
The [security page](http://rubyonrails.org/security/) mentions "CRSF" - I think this is supposed to be "CSRF" instead.