### PR TITLE
Add missing verb to doctrine page

### DIFF
--- a/doctrine.html
+++ b/doctrine.html
@@ -226,7 +226,7 @@ permalink: /doctrine/
 
       <p>Because the flip side of monkey patching is the power to do such feats of wonder as 2.days.ago (which returns a date two days back from the current). Now you might well think that’s a bad trade. That you’d rather lose 2.days.ago if it means preventing programmers from overwriting String#capitalize. If that’s your position, Ruby is probably not for you.</p>
 
-      <p>Yet it’d be hard even for people who would give up such freedom for some security that the power to change core classes and methods has doomed Ruby as a language. On the contrary, the language flourished exactly because it offered a different and radical perspective on the role of the programmer: That they could be trusted with sharp knives.</p>
+      <p>Yet it’d be hard — even for people who would give up such freedom for some security — to argue that the power to change core classes and methods has doomed Ruby as a language. On the contrary, the language flourished exactly because it offered a different and radical perspective on the role of the programmer: That they could be trusted with sharp knives.</p>
 
       <p>And not only trusted, but taught in the ways to use such capable tools. That we could elevate the entire profession by assuming most programmers would want to become better programmers, capable of wielding sharp knives without cutting off their fingers. That’s an incredibly aspirational idea, and one that runs counter to a lot of programmer’s intuition about other programmers.</p>
 


### PR DESCRIPTION
Previously the sentence (minus subordinate clauses) read "Yet it'd be hard that the power has doomed Ruby," which doesn't seem to be what's intended. Adding in "to argue that" seems to be the intent, so the core of the sentence is "Yet it'd be hard to argue that the power has doomed Ruby." I also added em-dashes to separate out a subordinate clause to make "it'd be hard to argue" easier to follow.