### PR TITLE
Use a proper apostrophe on the 404 page.

### DIFF
--- a/404.html
+++ b/404.html
@@ -5,5 +5,5 @@ sitemap: false
 ---
 
 <section>
-  <h1 style="text-align: center">You've gone off the Rails!</h1>
+  <h1 style="text-align: center">You’ve gone off the Rails!</h1>
 </section>


### PR DESCRIPTION
This isn't really a big deal, but it's a bit nicer?