### PR TITLE
Bump to v5.1.0.rc1 in the frontpage call-to-action

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,8 +28,8 @@ layout: default
     </section>
 
     <section class="version">
-      <p><a href="http://weblog.rubyonrails.org/2017/2/23/Rails-5-1-beta1/">Latest version &mdash; Rails 5.1.0.beta1 <span class="hide-mobile">released February 23, 2017</span></a></p>
-      <p class="show-mobile"><small>Released February 23, 2017</small></p>
+      <p><a href="http://weblog.rubyonrails.org/2017/3/20/Rails-5-1-rc1/">Latest version &mdash; Rails 5.1.0.rc1 <span class="hide-mobile">released March 20, 2017</span></a></p>
+      <p class="show-mobile"><small>Released March 20, 2017</small></p>
     </section>
 
     <section class="video-container">


### PR DESCRIPTION
This PR changes the text in the call-to-action on the frontpage.