### PR TITLE
Add abbr tag for the first occurrence of PoLS

### DIFF
--- a/doctrine.html
+++ b/doctrine.html
@@ -66,7 +66,7 @@ permalink: /doctrine/
     Use exit() or Ctrl-D (i.e. EOF) to exit</pre></code>
       </p>
 
-      <p>Ruby accepts both exit and quit to accommodate the programmer’s obvious desire to quit its interactive console. Python, on the other hand, pedantically instructs the programmer how to properly do what’s requested, even though it obviously knows what is meant (since it’s displaying the error message). That’s a pretty clear-cut, albeit small, example of PoLS.</p>
+      <p>Ruby accepts both exit and quit to accommodate the programmer’s obvious desire to quit its interactive console. Python, on the other hand, pedantically instructs the programmer how to properly do what’s requested, even though it obviously knows what is meant (since it’s displaying the error message). That’s a pretty clear-cut, albeit small, example of <abbr title="Principle of Least Surprise">PoLS</abbr>.</p>
 
       <p>The reason PoLS fell out of favor with the Ruby community was that this principle is inherently subjective. Least surprising to whom? Well, to Matz. And people who are surprised in the same way as him. As the Ruby community grew, and the ratio of people who were surprised by different things than Matz grew with it, this became a source of fruitless bike-shedding on the mailing lists. So the principle faded to the background, lest to invite more debates going nowhere over whether person X was surprised by behavior Y or not.</p>
 


### PR DESCRIPTION
We should give the definition of the PoLS abbreviation for the first occurrence in a text.