### PR TITLE
Use https with weblog URI

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@ layout: default
 
     <div class="nav">
       <ul>
-        <li class="first"><a href="http://weblog.rubyonrails.org/">Blog</a></li>
+        <li class="first"><a href="https://weblog.rubyonrails.org/">Blog</a></li>
         <li><a href="http://guides.rubyonrails.org/">Guides</a></li>
         <li><a href="http://api.rubyonrails.org/">API</a></li>
         <li><a href="http://stackoverflow.com/questions/tagged/ruby-on-rails">Ask for help</a></li>
@@ -28,7 +28,7 @@ layout: default
     </section>
 
     <section class="version">
-      <p><a href="http://weblog.rubyonrails.org/2018/4/9/Rails-5-2-0-final/">Latest version &mdash; Rails 5.2.0 <span class="hide-mobile">released April 9, 2018</span></a></p>
+      <p><a href="https://weblog.rubyonrails.org/2018/4/9/Rails-5-2-0-final/">Latest version &mdash; Rails 5.2.0 <span class="hide-mobile">released April 9, 2018</span></a></p>
       <p class="show-mobile"><small>Released April 9, 2018</small></p>
     </section>
 

--- a/security.html
+++ b/security.html
@@ -53,7 +53,7 @@ description: Ruby on Rails takes web security very seriously. This means includi
           Problem is confirmed and a list of all affected versions is determined. Code is audited to find any potential similar problems.</li>
           <li>Fixes are prepared for all releases which are still supported. These fixes are not committed to the public repository but rather held locally pending the announcement.</li>
           <li>A suggested embargo date for this vulnerability is chosen and <a href="http://oss-security.openwall.org/wiki/mailing-lists/distros">distros@openwall</a> is notified. This notification will include patches for all versions still under support and a contact address for packagers who need advice backporting patches to older versions.</li>
-          <li>On the embargo date, the rails security mailing list is sent a copy of the announcement. The changes are pushed to the public repository and new gems released to rubygems. At least 6 hours after the mailing list is notified, a copy of the advisory will be published on <a href="http://weblog.rubyonrails.org">the Rails weblog</a>.</li>
+          <li>On the embargo date, the rails security mailing list is sent a copy of the announcement. The changes are pushed to the public repository and new gems released to rubygems. At least 6 hours after the mailing list is notified, a copy of the advisory will be published on <a href="https://weblog.rubyonrails.org">the Rails weblog</a>.</li>
         </ol>
       </p>
 


### PR DESCRIPTION
I've changed weblog (GitHub page)'s protocol.

See: Custom domains on GitHub Pages gain support for HTTPS
https://blog.github.com/2018-05-01-github-pages-custom-domains-https/