### PR TITLE
Replace dead link on Ruby Rails doll

### DIFF
--- a/trademarks.html
+++ b/trademarks.html
@@ -27,7 +27,7 @@ description: “Rails”, “Ruby on Rails”, and the Rails logo are registered
         <ul>
           <li>Selling merchandise (stickers, t-shirts, mugs, etc).</li>
           <li>Use of the Rails logo on a book cover.</li>
-          <li>Products like the <a href="http://www.goldieblox.com/pages/heroes">Ruby Rails</a> doll.</li>
+          <li>Products like the <a href="https://www.amazon.com/dp/B0128K4PM8">Ruby Rails</a> doll.</li>
         </ul>
       </p>
 


### PR DESCRIPTION
It seems like GoldieBlox has moved their store to be on Amazon.com.