### PR TITLE
Update latest version to 6.0.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,8 +28,8 @@ layout: default
     </section>
 
     <section class="version">
-      <p><a href="https://weblog.rubyonrails.org/2019/3/28/Rails-5-2-3-has-been-released/">Latest version &mdash; Rails 5.2.3 <span class="hide-mobile">released March 28, 2019</span></a></p>
-      <p class="show-mobile"><small>Released March 28, 2019</small></p>
+      <p><a href="https://weblog.rubyonrails.org/2019/8/15/Rails-6-0-final-release/">Latest version &mdash; Rails 6.0.0 <span class="hide-mobile">released August 15, 2019</span></a></p>
+      <p class="show-mobile"><small>Released August 15, 2019</small></p>
     </section>
 
     <section class="video-container">


### PR DESCRIPTION
This PR updates the latest Rails version announcement link to 6.0.0.
https://weblog.rubyonrails.org/2019/8/15/Rails-6-0-final-release/