### PR TITLE
link from the Security Policy to the Maintenance Policy

### DIFF
--- a/security.html
+++ b/security.html
@@ -16,14 +16,7 @@ description: Ruby on Rails takes web security very seriously. This means includi
 
       <h2>Supported versions</h2>
 
-      <p>For major security issues, all releases in the current major series, and the last release in the additional major series will receive patches and new versions. This is currently 6.0.x and 5.2.x.</p>
-
-      <p>For minor security issues, the current release series and the next most recent one will receive patches and new versions. This is currently 6.0.x and 5.2.x.</p>
-
-      <p>When a release series is no longer supported, it’s your own responsibility to deal with bugs and security issues. We may provide backports of the fixes and publish them to git, however there will be no new versions released. If you are not comfortable maintaining your own versions, you should upgrade to a supported version.</p>
-
-      <p>The classification of a security issue is determined by the <a href="/community#core">Rails core team</a>.</p>
-
+      <p>See the <a href="https://guides.rubyonrails.org/maintenance_policy.html#security-issues">Maintenance Policy</a>.</p>
 
       <h2>Reporting a vulnerability</h2>
 


### PR DESCRIPTION
The latter contains more details about the versioning, as well as information about the Severe Security Issues category. Kudos to @dawnpm for pointing this out. Moreover, this deduplicates versioning information between the two pages.

Note the deployed Maintenance Policy page is still a major version behind. I couldn't find an open issue around that... Anyway, those versions were updated in https://github.com/rails/rails/commit/1c3c4f053f5b00dce5ed53570b2938977b830289.

Let us know what you think!