### PR TITLE
Update latest version to 6.0.2

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,8 +28,8 @@ layout: default
     </section>
 
     <section class="version">
-      <p><a href="https://weblog.rubyonrails.org/2019/11/5/Rails-6-0-1-released/">Latest version &mdash; Rails 6.0.1 <span class="hide-mobile">released November 5, 2019</span></a></p>
-      <p class="show-mobile"><small>Released November 5, 2019</small></p>
+      <p><a href="https://weblog.rubyonrails.org/2019/12/13/Rails-6-0-2-has-been-released/">Latest version &mdash; Rails 6.0.2 <span class="hide-mobile">released December 13, 2019</span></a></p>
+      <p class="show-mobile"><small>Released December 13, 2019</small></p>
     </section>
 
     <section class="video-container">


### PR DESCRIPTION
This PR updates the latest Rails version announcement link to 6.0.2.
https://weblog.rubyonrails.org/2019/12/13/Rails-6-0-2-has-been-released/