### PR TITLE
Update latest version to 6.0.3

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,8 +28,8 @@ layout: default
     </section>
 
     <section class="version">
-      <p><a href="https://weblog.rubyonrails.org/2020/3/19/Rails-6-0-2-2-and-5-2-4-2-has-been-released/">Latest version &mdash; Rails 6.0.2.2 <span class="hide-mobile">released March 19, 2020</span></a></p>
-      <p class="show-mobile"><small>Released March 19, 2020</small></p>
+      <p><a href="https://weblog.rubyonrails.org/2020/5/6/Rails-6-0-3-has-been-released/">Latest version &mdash; Rails 6.0.3 <span class="hide-mobile">released May 6, 2020</span></a></p>
+      <p class="show-mobile"><small>Released May 6, 2020</small></p>
     </section>
 
     <section class="video-container">


### PR DESCRIPTION
This PR updates the latest Rails version announcement link to 6.0.3.
https://weblog.rubyonrails.org/2020/5/6/Rails-6-0-3-has-been-released/