### PR TITLE
Update latest version to 6.0.3.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,8 +28,8 @@ layout: default
     </section>
 
     <section class="version">
-      <p><a href="https://weblog.rubyonrails.org/2020/5/6/Rails-6-0-3-has-been-released/">Latest version &mdash; Rails 6.0.3 <span class="hide-mobile">released May 6, 2020</span></a></p>
-      <p class="show-mobile"><small>Released May 6, 2020</small></p>
+      <p><a href="https://weblog.rubyonrails.org/2020/5/18/Rails-5-2-4-3-and-6-0-3-1-have-been-released/">Latest version &mdash; Rails 6.0.3.1 <span class="hide-mobile">released May 18, 2020</span></a></p>
+      <p class="show-mobile"><small>Released May 18, 2020</small></p>
     </section>
 
     <section class="video-container">


### PR DESCRIPTION
This PR updates the latest Rails version announcement link to 6.0.3.1.
https://weblog.rubyonrails.org/2020/5/18/Rails-5-2-4-3-and-6-0-3-1-have-been-released/