### PR TITLE
Updating latest release version on home page.

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,8 +28,8 @@ layout: default
     </section>
 
     <section class="version">
-      <p><a href="https://weblog.rubyonrails.org/2020/5/18/Rails-5-2-4-3-and-6-0-3-1-have-been-released/">Latest version &mdash; Rails 6.0.3.1 <span class="hide-mobile">released May 18, 2020</span></a></p>
-      <p class="show-mobile"><small>Released May 18, 2020</small></p>
+      <p><a href="https://weblog.rubyonrails.org/2020/6/17/Rails-6-0-3-2-has-been-released/">Latest version &mdash; Rails 6.0.3.2 <span class="hide-mobile">released May 18, 2020</span></a></p>
+      <p class="show-mobile"><small>Released June 17, 2020</small></p>
     </section>
 
     <section class="video-container">


### PR DESCRIPTION
Just noticed the home page hadn't been updated yet.

https://weblog.rubyonrails.org/2020/6/17/Rails-6-0-3-2-has-been-released/