### PR TITLE
Fixing instances of latest version release date.

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@ layout: default
     </section>
 
     <section class="version">
-      <p><a href="https://weblog.rubyonrails.org/2020/6/17/Rails-6-0-3-2-has-been-released/">Latest version &mdash; Rails 6.0.3.2 <span class="hide-mobile">released May 18, 2020</span></a></p>
+      <p><a href="https://weblog.rubyonrails.org/2020/6/17/Rails-6-0-3-2-has-been-released/">Latest version &mdash; Rails 6.0.3.2 <span class="hide-mobile">released June 17, 2020</span></a></p>
       <p class="show-mobile"><small>Released June 17, 2020</small></p>
     </section>
 


### PR DESCRIPTION
@kaspth I just checked the home page and realized there was two instances of the date, but since I only saw one on the site, I wasn't looking for two. This fixes the second one.