### PR TITLE
Update latest version to 6.0.3.3

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,8 +28,8 @@ layout: default
     </section>
 
     <section class="version">
-      <p><a href="https://weblog.rubyonrails.org/2020/6/17/Rails-6-0-3-2-has-been-released/">Latest version &mdash; Rails 6.0.3.2 <span class="hide-mobile">released June 17, 2020</span></a></p>
-      <p class="show-mobile"><small>Released June 17, 2020</small></p>
+      <p><a href="https://weblog.rubyonrails.org/2020/9/10/Rails-5-2-4-4-and-6-0-3-3-have-been-released/">Latest version &mdash; Rails 6.0.3.3 <span class="hide-mobile">released September 10, 2020</span></a></p>
+      <p class="show-mobile"><small>Released September 10, 2020</small></p>
     </section>
 
     <section class="video-container">


### PR DESCRIPTION
This PR updates the latest Rails version announcement link to 6.0.3.3.
https://weblog.rubyonrails.org/2020/9/10/Rails-5-2-4-4-and-6-0-3-3-have-been-released/