### PR TITLE
Update latest version to 6.1.2.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,8 +28,8 @@ layout: default
     </section>
 
     <section class="version">
-      <p><a href="https://weblog.rubyonrails.org/2020/12/9/Rails-6-1-0-release/">Latest version &mdash; Rails 6.1.0 <span class="hide-mobile">released December 9, 2020</span></a></p>
-      <p class="show-mobile"><small>Released December 9, 2020</small></p>
+      <p><a href="https://weblog.rubyonrails.org/2021/2/10/Rails-5-2-4-5-6-0-3-5-and-6-1-2-1-have-been-released/">Latest version &mdash; Rails 6.1.2.1 <span class="hide-mobile">released February 10, 2021</span></a></p>
+      <p class="show-mobile"><small>Released February 10, 2021</small></p>
     </section>
 
     <section class="video-container">


### PR DESCRIPTION
This PR updates the latest Rails version announcement link to 6.1.2.1.
https://weblog.rubyonrails.org/2021/2/10/Rails-5-2-4-5-6-0-3-5-and-6-1-2-1-have-been-released/