### PR TITLE
Update latest version to 6.1.3.2

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,8 +28,8 @@ layout: default
     </section>
 
     <section class="version">
-      <p><a href="https://weblog.rubyonrails.org/2021/3/26/marcel-upgrade-releases/">Latest version &mdash; Rails 6.1.3.1 <span class="hide-mobile">released March 26, 2021</span></a></p>
-      <p class="show-mobile"><small>Released March 26, 2021</small></p>
+      <p><a href="https://weblog.rubyonrails.org/2021/5/5/Rails-versions-6-1-3-2-6-0-3-7-5-2-4-6-and-5-2-6-have-been-released/">Latest version &mdash; Rails 6.1.3.2 <span class="hide-mobile">released May 5, 2021</span></a></p>
+      <p class="show-mobile"><small>Released May 5, 2021</small></p>
     </section>
 
     <section class="video-container">


### PR DESCRIPTION
This PR updates the latest Rails version announcement link to 6.1.3.2.
https://weblog.rubyonrails.org/2021/5/5/Rails-versions-6-1-3-2-6-0-3-7-5-2-4-6-and-5-2-6-have-been-released/