### PR TITLE
Remove Freenode reference in community page

### DIFF
--- a/community.html
+++ b/community.html
@@ -14,7 +14,7 @@ description: Ruby on Rails is for everyone who wants to build web applications, 
 
       <p>Ruby on Rails is for everyone who wants to build web applications, whether they're 30-year veterans or only just started to learn yesterday. All are welcome!</p>
 
-      <p>You can meet the community online on the <a href="https://discuss.rubyonrails.org/">Ruby on Rails Discussions</a>, <a href="http://stackoverflow.com/questions/tagged/ruby-on-rails">the Ruby on Rails StackOverflow Q&A tag</a>, or the #rubyonrails IRC channel on irc.freenode.net. We also do a yearly <a href="http://railsconf.com">RailsConf</a> conference for people to meet in real life.</p>
+      <p>You can meet the community online on the <a href="https://discuss.rubyonrails.org/">Ruby on Rails Discussions</a> or the <a href="http://stackoverflow.com/questions/tagged/ruby-on-rails">the Ruby on Rails StackOverflow Q&A tag</a>. We also do a yearly <a href="http://railsconf.com">RailsConf</a> conference for people to meet in real life.</p>
 
       <h2 id="core">The core team</h2>
 


### PR DESCRIPTION
Freenode is going through some changes - remove the reference until we know what's next.

Some people are gathering in #rubyonrails on Libera.chat, but it's still early on that front.