### PR TITLE
Update latest version to 6.1.4.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,8 +29,8 @@ layout: default
     </section>
 
     <section class="version">
-      <p><a href="https://weblog.rubyonrails.org/2021/6/24/Rails-6-1-4-has-been-released/">Latest version &mdash; Rails 6.1.4 <span class="hide-mobile">released June 24, 2021</span></a></p>
-      <p class="show-mobile"><small>Released June 24, 2021</small></p>
+      <p><a href="https://weblog.rubyonrails.org/2021/8/19/Rails-6-0-4-1-and-6-1-4-1-have-been-released/">Latest version &mdash; Rails 6.1.4.1<span class="hide-mobile">released August 19, 2021</span></a></p>
+      <p class="show-mobile"><small>Released August 19, 2021</small></p>
     </section>
 
     <section class="video-container">


### PR DESCRIPTION
This PR updates the latest Rails version announcement link to 6.1.4.1.
https://weblog.rubyonrails.org/2021/8/19/Rails-6-0-4-1-and-6-1-4-1-have-been-released/